### PR TITLE
Set the webpack target to electron-renderer

### DIFF
--- a/renderer/next.config.js
+++ b/renderer/next.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+  webpack(config) {
+    config.target = 'electron-renderer'
+    return config
+  },
   exportPathMap() {
     // Let Next.js know where to find the entry page
     // when it's exporting the static bundle for the use


### PR DESCRIPTION
Without that line if you try to import Electron modules (like `ipcRenderer`) or native modules (like `fs`) in the renderer process it will fail.